### PR TITLE
Avoid references to GLIBC_PRIVATE symbols

### DIFF
--- a/src/nis-spwd.c
+++ b/src/nis-spwd.c
@@ -32,11 +32,62 @@
 #include "libc-lock.h"
 #include "nss-nis.h"
 
-/* Get the declaration of the parser function.  */
+/* Predicate which always returns false, needed below.  */
+#define FALSEP(arg) 0
+
 #define ENTNAME spent
 #define STRUCTURE spwd
-#define EXTERN_PARSER
 #include "files-parse.c"
+LINE_PARSER
+(,
+ STRING_FIELD (result->sp_namp, ISCOLON, 0);
+ if (line[0] == '\0'
+     && (result->sp_namp[0] == '+' || result->sp_namp[0] == '-'))
+   {
+     result->sp_pwdp = NULL;
+     result->sp_lstchg = 0;
+     result->sp_min = 0;
+     result->sp_max = 0;
+     result->sp_warn = -1l;
+     result->sp_inact = -1l;
+     result->sp_expire = -1l;
+     result->sp_flag = ~0ul;
+   }
+ else
+   {
+     STRING_FIELD (result->sp_pwdp, ISCOLON, 0);
+     INT_FIELD_MAYBE_NULL (result->sp_lstchg, ISCOLON, 0, 10, (long int) (int),
+			   (long int) -1);
+     INT_FIELD_MAYBE_NULL (result->sp_min, ISCOLON, 0, 10, (long int) (int),
+			   (long int) -1);
+     INT_FIELD_MAYBE_NULL (result->sp_max, ISCOLON, 0, 10, (long int) (int),
+			   (long int) -1);
+     while (isspace (*line))
+       ++line;
+     if (*line == '\0')
+       {
+	 /* The old form.  */
+	 result->sp_warn = -1l;
+	 result->sp_inact = -1l;
+	 result->sp_expire = -1l;
+	 result->sp_flag = ~0ul;
+       }
+     else
+       {
+	 INT_FIELD_MAYBE_NULL (result->sp_warn, ISCOLON, 0, 10,
+			       (long int) (int), (long int) -1);
+	 INT_FIELD_MAYBE_NULL (result->sp_inact, ISCOLON, 0, 10,
+			       (long int) (int), (long int) -1);
+	 INT_FIELD_MAYBE_NULL (result->sp_expire, ISCOLON, 0, 10,
+			       (long int) (int), (long int) -1);
+	 if (*line != '\0')
+	   INT_FIELD_MAYBE_NULL (result->sp_flag, FALSEP, 0, 10,
+				 (unsigned long int), ~0ul)
+	 else
+	   result->sp_flag = ~0ul;
+       }
+   }
+ )
 
 /* Protect global state against multiple changers */
 __libc_lock_define_initialized (static, lock)


### PR DESCRIPTION
Copy more parser code from glibc to avoid a dependency on glibc
internals.