### PR TITLE
nis-hosts: Remove use of RES_USE_INET6

### DIFF
--- a/src/nis-hosts.c
+++ b/src/nis-hosts.c
@@ -35,15 +35,12 @@
 #include "libc-lock.h"
 #include "nss-nis.h"
 
-/* Get implementation for some internal functions. */
-#include "mapv4v6addr.h"
-
 #define ENTNAME         hostent
 #define DATABASE        "hosts"
 #define NEED_H_ERRNO
 
-#define EXTRA_ARGS      , af, flags
-#define EXTRA_ARGS_DECL , int af, int flags
+#define EXTRA_ARGS      , af
+#define EXTRA_ARGS_DECL , int af
 
 #define ENTDATA hostent_data
 struct hostent_data
@@ -67,19 +64,8 @@ LINE_PARSER
    /* Parse address.  */
    if (af != AF_INET6 && inet_pton (AF_INET, addr, entdata->host_addr) > 0)
      {
-       assert ((flags & AI_V4MAPPED) == 0 || af != AF_UNSPEC);
-       if (flags & AI_V4MAPPED)
-	 {
-	   map_v4v6_address ((char *) entdata->host_addr,
-			     (char *) entdata->host_addr);
-	   result->h_addrtype = AF_INET6;
-	   result->h_length = IN6ADDRSZ;
-	 }
-       else
-	 {
-	   result->h_addrtype = AF_INET;
-	   result->h_length = INADDRSZ;
-	 }
+       result->h_addrtype = AF_INET;
+       result->h_length = INADDRSZ;
      }
    else if (af != AF_INET
 	    && inet_pton (AF_INET6, addr, entdata->host_addr) > 0)
@@ -134,7 +120,7 @@ strong_alias (_nss_nis_sethostent, _nss_nis_endhostent)
 static enum nss_status
 internal_nis_gethostent_r (struct hostent *host, char *buffer,
 			   size_t buflen, int *errnop, int *h_errnop,
-			   int af, int flags)
+			   int af)
 {
   char *domain;
   if (yp_get_default_domain (&domain))
@@ -203,7 +189,7 @@ internal_nis_gethostent_r (struct hostent *host, char *buffer,
 	++p;
       free (result);
 
-      parse_res = parse_line (p, host, data, buflen, errnop, af, flags);
+      parse_res = parse_line (p, host, data, buflen, errnop, af);
       if (parse_res == -1)
 	{
 	  free (outkey);
@@ -232,8 +218,7 @@ _nss_nis_gethostent_r (struct hostent *host, char *buffer, size_t buflen,
   __libc_lock_lock (lock);
 
   status = internal_nis_gethostent_r (host, buffer, buflen, errnop, h_errnop,
-			((_res.options & RES_USE_INET6) ? AF_INET6 : AF_INET),
-			((_res.options & RES_USE_INET6) ? AI_V4MAPPED : 0 ));
+			AF_INET);
 
   __libc_lock_unlock (lock);
 
@@ -244,7 +229,7 @@ _nss_nis_gethostent_r (struct hostent *host, char *buffer, size_t buflen,
 static enum nss_status
 internal_gethostbyname2_r (const char *name, int af, struct hostent *host,
 			   char *buffer, size_t buflen, int *errnop,
-			   int *h_errnop, int flags)
+			   int *h_errnop)
 {
   uintptr_t pad = -(uintptr_t) buffer % __alignof__ (struct parser_data);
   buffer += pad;
@@ -318,7 +303,7 @@ internal_gethostbyname2_r (const char *name, int af, struct hostent *host,
     ++p;
   free (result);
 
-  int parse_res = parse_line (p, host, data, buflen, errnop, af, flags);
+  int parse_res = parse_line (p, host, data, buflen, errnop, af);
 
   if (parse_res < 1 || host->h_addrtype != af)
     {
@@ -351,8 +336,7 @@ _nss_nis_gethostbyname2_r (const char *name, int af, struct hostent *host,
     }
 
   return internal_gethostbyname2_r (name, af, host, buffer, buflen, errnop,
-				    h_errnop,
-			((_res.options & RES_USE_INET6) ? AI_V4MAPPED : 0));
+				    h_errnop);
 }
 
 
@@ -360,18 +344,8 @@ enum nss_status
 _nss_nis_gethostbyname_r (const char *name, struct hostent *host, char *buffer,
 			  size_t buflen, int *errnop, int *h_errnop)
 {
-  if (_res.options & RES_USE_INET6)
-    {
-      enum nss_status status;
-
-      status = internal_gethostbyname2_r (name, AF_INET6, host, buffer, buflen,
-					  errnop, h_errnop, AI_V4MAPPED);
-      if (status == NSS_STATUS_SUCCESS)
-	return status;
-    }
-
   return internal_gethostbyname2_r (name, AF_INET, host, buffer, buflen,
-				    errnop, h_errnop, 0);
+				    errnop, h_errnop);
 }
 
 
@@ -433,9 +407,7 @@ _nss_nis_gethostbyaddr_r (const void *addr, socklen_t addrlen, int af,
     ++p;
   free (result);
 
-  int parse_res = parse_line (p, host, data, buflen, errnop, af,
-			      ((_res.options & RES_USE_INET6)
-			       ? AI_V4MAPPED : 0));
+  int parse_res = parse_line (p, host, data, buflen, errnop, af);
   if (parse_res < 1)
     {
       if (parse_res == -1)
@@ -532,8 +504,7 @@ _nss_nis_gethostbyname4_r (const char *name, struct gaih_addrtuple **pat,
   buflen -= pad;
 
   struct hostent host;
-  int parse_res = parse_line (result, &host, data, buflen, errnop, AF_UNSPEC,
-			      0);
+  int parse_res = parse_line (result, &host, data, buflen, errnop, AF_UNSPEC);
   if (parse_res < 1)
     {
       if (parse_res == -1)


### PR DESCRIPTION
Upstream glibc dropped it starting glibc 2.30
see
https://sourceware.org/git/?p=glibc.git;a=commit;h=3f8b44be0a658266adff5ece1e4bc3ce097a5dbe

Fixes issue #6

Signed-off-by: Khem Raj <raj.khem@gmail.com>